### PR TITLE
Storage Service for the framework and Container to load services from array

### DIFF
--- a/Polyel/bootstrap.php
+++ b/Polyel/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 
-echo "Bootstrap process started...\n";
+echo "Creating Root Directory constant\n";
+define("ROOT_DIR", __DIR__);
+
+echo "Bootstrap process started...\n\n";
 
 $startingDirectory = new RecursiveDirectoryIterator(__DIR__ . "/src/");
 $pathIterator = new RecursiveIteratorIterator($startingDirectory);

--- a/Polyel/bootstrap.php
+++ b/Polyel/bootstrap.php
@@ -50,5 +50,7 @@ foreach ($polyelSourceFiles as $file)
 // Reset terminal colour back to normal.
 echo "\e[39m";
 
-// Create the DIC and create a new Polyel HTTP Server instance as the base class
-Polyel::createContainer(Polyel\Http\Server::class);
+$coreServices = require ROOT_DIR . "/Polyel/src/services.php";
+
+// Create the DIC and pass in an array of core services to be resolved
+Polyel::createContainer($coreServices);

--- a/Polyel/bootstrap.php
+++ b/Polyel/bootstrap.php
@@ -1,8 +1,5 @@
 <?php
 
-echo "Creating Root Directory constant\n";
-define("ROOT_DIR", __DIR__);
-
 echo "Bootstrap process started...\n\n";
 
 $startingDirectory = new RecursiveDirectoryIterator(__DIR__ . "/src/");

--- a/Polyel/src/Container/Container.class.php
+++ b/Polyel/src/Container/Container.class.php
@@ -9,18 +9,30 @@ class Container
     // Holds all the registered class instances
     private $container = [];
 
-    // Container Constructor. Can be passed a starting class to resolve as a base class.
-    public function __construct($baseClass = null)
+    // Can be passed an array of starting classes to resolve and be placed in the container
+    public function __construct($classesToResolve = null)
     {
-        if(isset($baseClass))
+        if(isset($classesToResolve))
         {
-            $this->checkForDependencies($baseClass);
+            // Resolve each class inside the array that was passed in
+            foreach($classesToResolve as $class)
+            {
+                // Each class is then stored inside the container
+                $this->checkForDependencies($class);
+            }
         }
     }
 
     // Recursively checks for class dependencies, resolves them and creates class instances.
     private function checkForDependencies($classToResolve)
     {
+        // Return when the class already exists inside the container
+        if($this->get($classToResolve))
+        {
+            // Stops classes being overwritten again if called to be resolved
+            return;
+        }
+
         // Using Reflection, load the class up...
         $classReflection = new ReflectionClass($classToResolve);
 

--- a/Polyel/src/Storage/Facade/Storage.class.php
+++ b/Polyel/src/Storage/Facade/Storage.class.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Polyel\Storage\Facade;
+
+use Polyel;
+
+class Storage
+{
+    public static function __callStatic($method, $arguments)
+    {
+        return Polyel::call(Polyel\Storage\Storage::class)->$method($arguments);
+    }
+}

--- a/Polyel/src/Storage/LocalStorageDriver.class.php
+++ b/Polyel/src/Storage/LocalStorageDriver.class.php
@@ -171,4 +171,16 @@ class LocalStorage
             }
         });
     }
+
+    public function makeDir($dirPath, $mode = 0777)
+    {
+        // Recursively create the directory path given using the mode that was set
+        return mkdir(ROOT_DIR . $dirPath, $mode, true);
+    }
+
+    public function removeDir($dirPath)
+    {
+        // Only deletes a directory that is empty
+        return rmdir(ROOT_DIR . $dirPath);
+    }
 }

--- a/Polyel/src/Storage/LocalStorageDriver.class.php
+++ b/Polyel/src/Storage/LocalStorageDriver.class.php
@@ -150,4 +150,25 @@ class LocalStorage
             rename($oldName, $newName);
         });
     }
+
+    public function delete($filePath)
+    {
+        // Defer the delete process
+        Swoole::create(function() use ($filePath)
+        {
+            // When the filePath is a single string
+            if(!is_array($filePath))
+            {
+                unlink(ROOT_DIR . $filePath);
+            }
+            else
+            {
+                // For when an array of filePaths are passed in for deletion
+                foreach ($filePath as $path)
+                {
+                    unlink(ROOT_DIR . $path);
+                }
+            }
+        });
+    }
 }

--- a/Polyel/src/Storage/LocalStorageDriver.class.php
+++ b/Polyel/src/Storage/LocalStorageDriver.class.php
@@ -36,6 +36,28 @@ class LocalStorage
         return $this;
     }
 
+    // Send back the file size in a human readable format
+    public function size($filePath)
+    {
+        $filePath = ROOT_DIR . $filePath;
+
+        // Don't continue if the file does not exist
+        if(!file_exists($filePath))
+        {
+            throw new Exception("ERROR: Cannot get file size, file does not exist: " . $filePath);
+        }
+
+        // Remove cached information so that filesize() is accurate
+        clearstatcache();
+        $bytes = filesize($filePath);
+
+        // Convert bytes to a human readable format and return the final value with its unit
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+        for ($i = 0; $bytes > 1024; $i++) $bytes /= 1024;
+
+        return round($bytes, 2) . $units[$i];
+    }
+
     // Read a file and return the raw string content
     public function read($filePath)
     {

--- a/Polyel/src/Storage/LocalStorageDriver.class.php
+++ b/Polyel/src/Storage/LocalStorageDriver.class.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Polyel\Storage;
+
+use Exception;
+use Swoole\Coroutine as Swoole;
+
+class LocalStorage
+{
+    // Default links to some important directories
+    private $directoryLinks = [
+        "app" => ROOT_DIR . "/app",
+        "controllers" => ROOT_DIR . "/app/Controllers",
+        "views" => ROOT_DIR . "/app/views",
+        "public" => ROOT_DIR . "/public",
+        "config" => ROOT_DIR . "/config",
+        "storage" => ROOT_DIR . "/storage",
+        "src" => ROOT_DIR . "/Polyel/src",
+    ];
+
+    // Used to set a common directory link
+    private $fromLink;
+
+    public function __construct()
+    {
+
+    }
+
+    // Used to start reading from a common directory link
+    public function from($fromLink)
+    {
+        $this->fromLink = $fromLink;
+        return $this;
+    }
+
+    // Read a file and return the raw string content
+    public function read($filePath)
+    {
+        // Check if a from link has been set
+        if(isset($this->fromLink))
+        {
+            $filePath = $this->directoryLinks[strtolower($this->fromLink)] . $filePath;
+        }
+
+        if(!file_exists($filePath))
+        {
+            throw new Exception("Read Error: File not found at " . $filePath);
+        }
+
+        // Open a resource handle
+        $handle = fopen(realpath($filePath), "rb");
+
+        // Read the entire file and close the handle afterwards
+        $file = Swoole::fread($handle, filesize($filePath));
+        fclose($handle);
+
+        // Reset the from link
+        $this->fromLink = null;
+
+        // Return the file contents as a string
+        return $file;
+    }
+}

--- a/Polyel/src/Storage/LocalStorageDriver.class.php
+++ b/Polyel/src/Storage/LocalStorageDriver.class.php
@@ -128,4 +128,26 @@ class LocalStorage
         // Reset the write mode back to the default
         $this->writeMode = "c";
     }
+
+    public function copy($source, $dest)
+    {
+        $source = ROOT_DIR . $source;
+        $dest = ROOT_DIR . $dest;
+
+        Swoole::create(function() use ($source, $dest)
+        {
+            copy($source, $dest);
+        });
+    }
+
+    public function move($oldName, $newName)
+    {
+        $oldName = ROOT_DIR . $oldName;
+        $newName = ROOT_DIR . $newName;
+
+        Swoole::create(function() use ($oldName, $newName)
+        {
+            rename($oldName, $newName);
+        });
+    }
 }

--- a/Polyel/src/Storage/Storage.class.php
+++ b/Polyel/src/Storage/Storage.class.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Polyel\Storage;
+
+class Storage
+{
+    // Holds the storage driver for local operators
+    private $localStorage;
+
+    public function __construct(LocalStorage $localStorage)
+    {
+        $this->localStorage = $localStorage;
+    }
+
+    // The access function is the gateway to all the storage drivers
+    public function access($storageLocation)
+    {
+        // Use a switch to determine which storage driver is needed
+        switch (strtolower(...$storageLocation))
+        {
+            // Local storage driver for local filesystem access
+            case 'local':
+
+                return $this->localStorage;
+
+                break;
+        }
+
+        // Return NULL when no storage driver match is found
+        return NULL;
+    }
+}

--- a/Polyel/src/services.php
+++ b/Polyel/src/services.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * An array to hold all the core services which need to be resolved into the
+ * container. The fully qualified namespace is needed to resolve a class.
+ */
+return [
+
+    Polyel\Config\Config::class,
+    Polyel\Controller\Controller::class,
+    Polyel\Debug\Debug::class,
+    Polyel\Http\Server::class,
+    Polyel\Middleware\Middleware::class,
+    Polyel\Router\Router::class,
+    Polyel\Storage\Storage::class,
+    Polyel\Storage\LocalStorage::class,
+    Polyel\Time\Time::class,
+    Polyel\View\View::class,
+
+];

--- a/config/filesystem.php
+++ b/config/filesystem.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+
+    "storage" => [
+
+        "local" => [
+            "root" => ROOT_DIR . "/storage/app",
+        ]
+
+    ]
+
+];

--- a/server.php
+++ b/server.php
@@ -1,5 +1,8 @@
 <?php
 
+echo "Creating Root Directory constant\n";
+define("ROOT_DIR", __DIR__);
+
 require __DIR__ . "/Polyel/bootstrap.php";
 
 $server = Polyel::call(Polyel\Http\Server::class);


### PR DESCRIPTION
During development, the container would not work with classes unless they were required by a previous class and because this storage class was not used inside the core yet, it was never defined fully, so this PR also includes a change to the container to resolve core classes from a list of services, which means all core services are available even if they are not used before they are required inside a controller for example. Once merged, the new Container resolve process won't affect other services, it just means they will all be loaded if not used already, they just need to be registered in the `services.php` file.