### PR TITLE
Implement support for encryption

### DIFF
--- a/Polyel/src/Encryption/AesCbcEncrypter.class.php
+++ b/Polyel/src/Encryption/AesCbcEncrypter.class.php
@@ -97,12 +97,12 @@ class AesCbcEncrypter implements Encryption
 
     public function encryptString($string)
     {
-
+        return $this->encrypt($string, false);
     }
 
     public function decryptString($payload)
     {
-
+        return $this->decrypt($payload, false);
     }
 
     private function hashForMac($iv, $data)

--- a/Polyel/src/Encryption/AesCbcEncrypter.class.php
+++ b/Polyel/src/Encryption/AesCbcEncrypter.class.php
@@ -20,7 +20,6 @@ class AesCbcEncrypter implements Encryption
 
     public function encrypt($data, $serialize = true)
     {
-
         // The initialisation vector
         $ivector = random_bytes(openssl_cipher_iv_length($this->cipher));
 

--- a/Polyel/src/Encryption/AesCbcEncrypter.class.php
+++ b/Polyel/src/Encryption/AesCbcEncrypter.class.php
@@ -6,7 +6,7 @@ use JsonException;
 use Polyel\Encryption\Exception\EncryptionException;
 use Polyel\Encryption\Exception\DecryptionException;
 
-class Encrypter implements Encryption
+class AesCbcEncrypter implements Encryption
 {
     private string $key;
 

--- a/Polyel/src/Encryption/AesGcmEncrypter.class.php
+++ b/Polyel/src/Encryption/AesGcmEncrypter.class.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Polyel\Encryption;
+
+use JsonException;
+use Polyel\Encryption\Exception\EncryptionException;
+use Polyel\Encryption\Exception\DecryptionException;
+
+class AesGcmEncrypter implements Encryption
+{
+    private string $key;
+
+    private string $cipher;
+
+    public function __construct($key, $cipher)
+    {
+        $this->key = $key;
+        $this->cipher = $cipher;
+    }
+
+    public function encrypt($data, $serialize = true)
+    {
+        // The initialisation vector for the GCM cipher
+        $ivector = random_bytes(openssl_cipher_iv_length($this->cipher));
+
+        /*
+         * Go ahead and try and encrypt the data with the iv, key and selected cipher
+         * The data is passed through the PHP serialize function if $serialize if set to true.
+         */
+        $encrypted = openssl_encrypt(
+            $serialize ? serialize($data) : $data,
+            $this->cipher,
+            $this->key,
+            0,
+            $ivector,
+            $tag);
+
+        // Only proceed if the encryption was successful
+        if($encrypted === false)
+        {
+            throw new EncryptionException('Encryption failed, data could not be encrypted with openssl');
+        }
+
+        // Convert the iv and GCM tag to a storable representation for JSON
+        $ivector = base64_encode($ivector);
+        $tag = base64_encode($tag);
+
+        try
+        {
+            // Store the encrypted data with its iv and hmac hash using JSON
+            $payload = json_encode(compact('ivector', 'encrypted', 'tag'), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        }
+        catch(JsonException $e)
+        {
+            // Catch and throw any JSON encoding errors...
+            throw new EncryptionException('Encryption failed during payload packing: ' . $e->getMessage());
+        }
+
+        if($payload !== false)
+        {
+            // If the JSON encode was successful we can convert everything to bse64 for easier storage
+            $payload = base64_encode($payload);
+        }
+
+        // Return the encrypted payload
+        return $payload;
+    }
+
+    public function decrypt($payload, $unserialize = true)
+    {
+        // Because the payload is formatted using JSON which holds encryption details, decode the base64 data...
+        $payload = $this->decodePayload($payload);
+
+        // The payload could not be decoded, invalid payload format
+        if($payload === false)
+        {
+            throw new DecryptionException('Decryption failed, invalid payload');
+        }
+
+        // Decode the iv and GCM tag to their raw values
+        $ivector = base64_decode($payload['ivector']);
+        $tag = base64_decode($payload['tag']);
+
+        $decrypted = openssl_decrypt($payload['encrypted'], $this->cipher, $this->key, 0, $ivector, $tag);
+
+        if($decrypted === false)
+        {
+            throw new DecryptionException('Decryption failed using openssl');
+        }
+
+        // Return the decrypted data and unserialize the data if set to true
+        return $unserialize ? unserialize($decrypted, ['allowed_classes' => false]) : $decrypted;
+    }
+
+    public function encryptString($string)
+    {
+        return $this->encrypt($string, false);
+    }
+
+    public function decryptString($payload)
+    {
+        return $this->decrypt($payload, false);
+    }
+
+    private function decodePayload($payload)
+    {
+        try
+        {
+            // Decode the payload from base64 and then decode it from JSON...
+            $payload = json_decode(base64_decode($payload), true, 1024, JSON_THROW_ON_ERROR);
+        }
+        catch(JsonException $e)
+        {
+            // Catch any JSON decoding errors...
+            throw new DecryptionException('Decryption failed on payload decoding: ' . $e->getMessage());
+        }
+
+        // If JSON decoding was not fully successful, the payload is either false or not an array
+        if($payload === false || !is_array($payload))
+        {
+            return false;
+        }
+
+        // Make sure we have all the required encryption details from the encoded JSON payload
+        if(!exists($payload['ivector']) || !exists($payload['encrypted']) || !exists($payload['tag']))
+        {
+            return false;
+        }
+
+        // Validate that the iv is the same length as the required cipher iv length
+        if(mb_strlen(base64_decode($payload['ivector'], true), '8bit') !== openssl_cipher_iv_length($this->cipher))
+        {
+            return false;
+        }
+
+        // Finally return the decoded JSON payload if no errors were found
+        return $payload;
+    }
+}

--- a/Polyel/src/Encryption/Encrypter.class.php
+++ b/Polyel/src/Encryption/Encrypter.class.php
@@ -2,6 +2,10 @@
 
 namespace Polyel\Encryption;
 
+use JsonException;
+use Polyel\Encryption\Exception\EncryptionException;
+use Polyel\Encryption\Exception\DecryptionException;
+
 class Encrypter implements Encryption
 {
     private string $key;
@@ -17,11 +21,78 @@ class Encrypter implements Encryption
     public function encrypt($data, $serialize = true)
     {
 
+        // The initialisation vector
+        $ivector = random_bytes(openssl_cipher_iv_length($this->cipher));
+
+        /*
+         * Go ahead and try and encrypt the data with the iv, key and selected cipher
+         * The data is passed through the PHP serialize function if $serialize if set to true.
+         */
+        $encrypted = openssl_encrypt(
+            $serialize ? serialize($data) : $data,
+            $this->cipher,
+            $this->key,
+            0,
+            $ivector);
+
+        // Only proceed if the encryption was successful
+        if($encrypted === false)
+        {
+            throw new EncryptionException('Encryption failed, data could not be encrypted with openssl');
+        }
+
+        // Calculate the message authentication code (MAC) used to detect data changes during decryption
+        $hmac = $this->hashForMac($ivector = base64_encode($ivector), $encrypted);
+
+        try
+        {
+            // Store the encrypted data with its iv and hmac hash using JSON
+            $payload = json_encode(compact('ivector', 'encrypted', 'hmac'), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        }
+        catch(JsonException $e)
+        {
+            // Catch and throw any JSON encoding errors...
+            throw new EncryptionException('Encryption failed during payload packing: ' . $e->getMessage());
+        }
+
+        if($payload !== false)
+        {
+            // If the JSON encode was successful we can convert everything to bse64 for easier storage
+            $payload = base64_encode($payload);
+        }
+
+        // Return the encrypted payload
+        return $payload;
     }
 
     public function decrypt($payload, $unserialize = true)
     {
+        // Because the payload is formatted using JSON which holds encryption details, decode the base64 data...
+        $payload = $this->decodePayload($payload);
 
+        // The payload could not be decoded, invalid payload format
+        if($payload === false)
+        {
+            throw new DecryptionException('Decryption failed, invalid payload');
+        }
+
+        // Validate that the message authentication code (MAC) has not changed
+        if($this->validateHMAC($payload) === false)
+        {
+            throw new DecryptionException('Decryption failed, invalid HMAC comparison, data has been changed');
+        }
+
+        $ivector = base64_decode($payload['ivector']);
+
+        $decrypted = openssl_decrypt($payload['encrypted'], $this->cipher, $this->key, 0, $ivector);
+
+        if($decrypted === false)
+        {
+            throw new DecryptionException('Decryption failed using openssl');
+        }
+
+        // Return the decrypted data and unserialize the data if set to true
+        return $unserialize ? unserialize($decrypted, ['allowed_classes' => false]) : $decrypted;
     }
 
     public function encryptString($string)
@@ -37,5 +108,66 @@ class Encrypter implements Encryption
     private function hashForMac($iv, $data)
     {
         return hash_hmac('sha256', $iv.$data, $this->key);
+    }
+
+    private function decodePayload($payload)
+    {
+        try
+        {
+            // Decode the payload from base64 and then decode it from JSON...
+            $payload = json_decode(base64_decode($payload), true, 1024, JSON_THROW_ON_ERROR);
+        }
+        catch(JsonException $e)
+        {
+            // Catch any JSON decoding errors...
+            throw new DecryptionException('Decryption failed on payload decoding: ' . $e->getMessage());
+        }
+
+        // If JSON decoding was not fully successful, the payload is either false or not an array
+        if($payload === false || !is_array($payload))
+        {
+            return false;
+        }
+
+        // Make sure we have all the required encryption details from the encoded JSON payload
+        if(!exists($payload['ivector']) || !exists($payload['encrypted']) || !exists($payload['hmac']))
+        {
+            return false;
+        }
+
+        // Validate that the iv is the same length as the required cipher iv length
+        if(mb_strlen(base64_decode($payload['ivector'], true), '8bit') !== openssl_cipher_iv_length($this->cipher))
+        {
+            return false;
+        }
+
+        // Finally return the decoded JSON payload if no errors were found
+        return $payload;
+    }
+
+    private function validateHMAC($payload)
+    {
+        // Key used to validate encrypted payload has not been changed
+        $bytes = random_bytes(16);
+
+        // Calculate a mac hash based on the payload and our random bytes
+        $calcMac = $this->calculateMac($payload, $bytes);
+
+        // Get the payload mac hash using the same bytes key
+        $payloadMac = hash_hmac('sha256', $payload['hmac'], $bytes, true);
+
+        // Both the payload mac and calculated mac should match if the encrypted data was not changed
+        if(hash_equals($payloadMac, $calcMac))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function calculateMac($payload, $bytes)
+    {
+        // Return a caclulated mac hash based on the payload iv and encrypted data with the random bytes key provided
+        return hash_hmac('sha256', $this->hashForMac($payload['ivector'], $payload['encrypted']), $bytes, true);
     }
 }

--- a/Polyel/src/Encryption/Encrypter.class.php
+++ b/Polyel/src/Encryption/Encrypter.class.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Polyel\Encryption;
+
+class Encrypter implements Encryption
+{
+    private string $key;
+
+    private string $cipher;
+
+    public function __construct($key, $cipher)
+    {
+        $this->key = $key;
+        $this->cipher = $cipher;
+    }
+
+    public function encrypt($data, $serialize = true)
+    {
+
+    }
+
+    public function decrypt($payload, $unserialize = true)
+    {
+
+    }
+
+    public function encryptString($string)
+    {
+
+    }
+
+    public function decryptString($payload)
+    {
+
+    }
+}

--- a/Polyel/src/Encryption/Encrypter.class.php
+++ b/Polyel/src/Encryption/Encrypter.class.php
@@ -33,4 +33,9 @@ class Encrypter implements Encryption
     {
 
     }
+
+    private function hashForMac($iv, $data)
+    {
+        return hash_hmac('sha256', $iv.$data, $this->key);
+    }
 }

--- a/Polyel/src/Encryption/Encryption.interface.php
+++ b/Polyel/src/Encryption/Encryption.interface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Polyel\Encryption;
+
+interface Encryption
+{
+    public function encrypt();
+
+    public function decrypt();
+
+    public function encryptString();
+
+    public function decryptString();
+}

--- a/Polyel/src/Encryption/Encryption.interface.php
+++ b/Polyel/src/Encryption/Encryption.interface.php
@@ -4,11 +4,11 @@ namespace Polyel\Encryption;
 
 interface Encryption
 {
-    public function encrypt();
+    public function encrypt($data, $serialize = true);
 
-    public function decrypt();
+    public function decrypt($payload, $unserialize = true);
 
-    public function encryptString();
+    public function encryptString($string);
 
-    public function decryptString();
+    public function decryptString($payload);
 }

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -32,7 +32,7 @@ class EncryptionManager implements Encryption
             {
                 $this->key = $key;
                 $this->cipher = $cipher;
-                $this->encrypter = new Encrypter($this->key, $this->cipher);
+                $this->encrypter = new AesCbcEncrypter($this->key, $this->cipher);
 
                 $this->initialised = true;
             }

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -6,6 +6,8 @@ use RuntimeException;
 
 class EncryptionManager implements Encryption
 {
+    private $initialised;
+
     private $encrypter;
 
     private string $key;
@@ -14,25 +16,30 @@ class EncryptionManager implements Encryption
 
     public function __construct()
     {
-
+        $this->initialised = false;
     }
 
     public function setup()
     {
-        $key = config('main.encryptionKey');
-        $cipher = config('main.encryptionCipher');
-
-        $key = base64_decode($key);
-
-        if($this->validateKeyAndCipher($key, $cipher))
+        if($this->initialised === false)
         {
-            $this->key = $key;
-            $this->cipher = $cipher;
-            $this->encrypter = new Encrypter($this->key, $this->cipher);
-        }
-        else
-        {
-            throw new RuntimeException('Encryption key and cipher not compatible, only AES-128-CBC (16 bit) & AES-256-CBC (32 bit) are supported');
+            $key = config('main.encryptionKey');
+            $cipher = config('main.encryptionCipher');
+
+            $key = base64_decode($key);
+
+            if($this->validateKeyAndCipher($key, $cipher))
+            {
+                $this->key = $key;
+                $this->cipher = $cipher;
+                $this->encrypter = new Encrypter($this->key, $this->cipher);
+
+                $this->initialised = true;
+            }
+            else
+            {
+                throw new RuntimeException('Encryption key and cipher not compatible, only AES-128-CBC (16 bit) & AES-256-CBC (32 bit) are supported');
+            }
         }
     }
 

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -30,11 +30,31 @@ class EncryptionManager implements Encryption
 
             if($this->validateKeyAndCipher($key, $cipher))
             {
-                $this->key = $key;
-                $this->cipher = $cipher;
-                $this->encrypter = new AesCbcEncrypter($this->key, $this->cipher);
+                switch($cipher)
+                {
+                    case 'AES-128-CBC':
+                    case 'AES-256-CBC':
 
-                $this->initialised = true;
+                    $this->key = $key;
+                    $this->cipher = $cipher;
+                    $this->encrypter = new AesCbcEncrypter($this->key, $this->cipher);
+
+                    break;
+
+                    case 'AES-128-GCM':
+                    case 'AES-256-GCM':
+
+                    $this->key = $key;
+                    $this->cipher = $cipher;
+                    $this->encrypter = new AesGcmEncrypter($this->key, $this->cipher);
+
+                    break;
+                }
+
+                if(exists($this->encrypter))
+                {
+                    $this->initialised = true;
+                }
             }
             else
             {

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -64,12 +64,14 @@ class EncryptionManager implements Encryption
         switch($cipher)
         {
             case 'AES-128-CBC':
+            case 'AES-128-GCM':
 
                 $keyLen = 16;
 
             break;
 
             case 'AES-256-CBC':
+            case 'AES-256-GCM':
 
                 $keyLen = 32;
 

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -49,7 +49,28 @@ class EncryptionManager implements Encryption
         {
             $keyLength = mb_strlen($key, '8bit');
 
-            return ($cipher === 'AES-128-CBC' && $keyLength === 16) || ($cipher === 'AES-256-CBC' && $keyLength === 32);
+            switch($cipher)
+            {
+                case 'AES-128-CBC':
+                case 'AES-128-GCM':
+
+                    $cipherLength = 16;
+
+                break;
+
+                case 'AES-256-CBC':
+                case 'AES-256-GCM':
+
+                    $cipherLength = 32;
+
+                break;
+
+                default:
+
+                    $cipherLength = null;
+            }
+
+            return ($cipherLength === $keyLength);
         }
         else
         {

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -57,9 +57,26 @@ class EncryptionManager implements Encryption
         }
     }
 
-    public function generateEncryptionKey()
+    public function generateEncryptionKey($cipher = null)
     {
-        $randomKey = random_bytes(config('main.encryptionCipher') === 'AES-128-CBC' ? 16 : 32);
+        $cipher = $cipher ?? config('main.encryptionCipher');
+
+        switch($cipher)
+        {
+            case 'AES-128-CBC':
+
+                $keyLen = 16;
+
+            break;
+
+            case 'AES-256-CBC':
+
+                $keyLen = 32;
+
+            break;
+        }
+
+        $randomKey = random_bytes($keyLen);
 
         return base64_encode($randomKey);
     }

--- a/Polyel/src/Encryption/EncryptionManager.class.php
+++ b/Polyel/src/Encryption/EncryptionManager.class.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Polyel\Encryption;
+
+use RuntimeException;
+
+class EncryptionManager implements Encryption
+{
+    private $encrypter;
+
+    private string $key;
+
+    private string $cipher;
+
+    public function __construct()
+    {
+
+    }
+
+    public function setup()
+    {
+        $key = config('main.encryptionKey');
+        $cipher = config('main.encryptionCipher');
+
+        $key = base64_decode($key);
+
+        if($this->validateKeyAndCipher($key, $cipher))
+        {
+            $this->key = $key;
+            $this->cipher = $cipher;
+            $this->encrypter = new Encrypter($this->key, $this->cipher);
+        }
+        else
+        {
+            throw new RuntimeException('Encryption key and cipher not compatible, only AES-128-CBC (16 bit) & AES-256-CBC (32 bit) are supported');
+        }
+    }
+
+    private function validateKeyAndCipher($key, $cipher)
+    {
+        if(in_array('8bit', mb_list_encodings()))
+        {
+            $keyLength = mb_strlen($key, '8bit');
+
+            return ($cipher === 'AES-128-CBC' && $keyLength === 16) || ($cipher === 'AES-256-CBC' && $keyLength === 32);
+        }
+        else
+        {
+            throw new RuntimeException('Cannot verify encryption key & cipher because mbstring lib is not installed');
+        }
+    }
+
+    public function generateEncryptionKey()
+    {
+        $randomKey = random_bytes(config('main.encryptionCipher') === 'AES-128-CBC' ? 16 : 32);
+
+        return base64_encode($randomKey);
+    }
+
+    public function getEncryptionKey()
+    {
+        return $this->key;
+    }
+
+    public function encrypt($data, $serialize = true)
+    {
+        return $this->encrypter->encrypt($data, $serialize);
+    }
+
+    public function decrypt($payload, $unserialize = true)
+    {
+        return $this->encrypter->decrypt($payload, $unserialize);
+    }
+
+    public function encryptString($string)
+    {
+        return $this->encrypt($string, false);
+    }
+
+    public function decryptString($payload)
+    {
+        return $this->decrypt($payload, false);
+    }
+}

--- a/Polyel/src/Encryption/Exceptions/DecryptionException.class.php
+++ b/Polyel/src/Encryption/Exceptions/DecryptionException.class.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Polyel\Encryption\Exception;
+
+use RuntimeException;
+
+class DecryptionException extends RuntimeException
+{
+    //...
+}

--- a/Polyel/src/Encryption/Exceptions/EncryptionException.class.php
+++ b/Polyel/src/Encryption/Exceptions/EncryptionException.class.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Polyel\Encryption\Exception;
+
+use RuntimeException;
+
+class EncryptionException extends RuntimeException
+{
+    //...
+}

--- a/Polyel/src/Encryption/Facade/Crypt.php
+++ b/Polyel/src/Encryption/Facade/Crypt.php
@@ -4,6 +4,12 @@ namespace Polyel\Encryption\Facade;
 
 use Polyel;
 
+/**
+ * @method static encrypt($data, $serialize = true)
+ * @method static decrypt($payload, $unserialize = true)
+ * @method static encryptString($string)
+ * @method static decryptString($payload)
+ */
 class Crypt
 {
     public static function __callStatic($method, $arguments)

--- a/Polyel/src/Encryption/Facade/Crypt.php
+++ b/Polyel/src/Encryption/Facade/Crypt.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Polyel\Encryption\Facade;
+
+use Polyel;
+
+class Crypt
+{
+    public static function __callStatic($method, $arguments)
+    {
+        return Polyel::call(Polyel\Encryption\EncryptionManager::class)->$method(...$arguments);
+    }
+}

--- a/Polyel/src/Encryption/Facade/Crypt.php
+++ b/Polyel/src/Encryption/Facade/Crypt.php
@@ -9,6 +9,7 @@ use Polyel;
  * @method static decrypt($payload, $unserialize = true)
  * @method static encryptString($string)
  * @method static decryptString($payload)
+ * @method static generateEncryptionKey($cipher = null)
  */
 class Crypt
 {

--- a/Polyel/src/Http/Server.class.php
+++ b/Polyel/src/Http/Server.class.php
@@ -13,6 +13,7 @@ use Polyel\View\Element\Element;
 use Polyel\Controller\Controller;
 use Polyel\Middleware\Middleware;
 use Polyel\Session\SessionManager;
+use Polyel\Encryption\Facade\Crypt;
 use Polyel\Database\DatabaseManager;
 use Swoole\HTTP\Server as SwooleHTTPServer;
 
@@ -59,6 +60,8 @@ class Server
         $this->middleware->loadAllMiddleware();
 
         $this->sessionManager->setDriver(config('session.driver'));
+
+        Crypt::setup();
 
         Hash::setup();
 

--- a/Polyel/src/helperFunctions/encryption.php
+++ b/Polyel/src/helperFunctions/encryption.php
@@ -1,0 +1,11 @@
+<?php
+
+function encrypt($data, $serialize = true)
+{
+    return Polyel::call(Polyel\Encryption\EncryptionManager::class)->encrypt($data, $serialize);
+}
+
+function decrypt($payload, $unserialize = true)
+{
+    return Polyel::call(Polyel\Encryption\EncryptionManager::class)->decrypt($payload, $unserialize);
+}

--- a/Polyel/src/services.php
+++ b/Polyel/src/services.php
@@ -19,6 +19,7 @@ $coreServices = [
     Polyel\Storage\Storage::class,
     Polyel\Database\Database::class,
     Polyel\View\View::class,
+    Polyel\Encryption\EncryptionManager::class,
     Polyel\Hashing\HashManager::class,
 
 ];

--- a/config/env/.env.example
+++ b/config/env/.env.example
@@ -1,3 +1,7 @@
+# Encryption Settings
+[Encryption]
+KEY=""
+
 # Database Settings
 [Database]
 Default_Connection="default"

--- a/config/main.php
+++ b/config/main.php
@@ -14,7 +14,9 @@ return [
     | You must set a securely generated key with the correct length if you want your
     | encrypted data to be safe.
     |
-    | Current supported ciphers are: AES-128-CBC, AES-256-CBC
+    | Current supported ciphers are:
+    |   AES-128-CBC, AES-256-CBC,
+    |   AES-128-GCM, AES-256-GCM
     │
     */
     "encryptionKey" => env('Encryption.KEY', ''),

--- a/config/main.php
+++ b/config/main.php
@@ -4,4 +4,8 @@ return [
 
     "appName" => "Polyel",
 
+    "encryptionKey" => env('Encryption.KEY'),
+
+    "encryptionCipher" => "AES-256-CBC",
+
 ];

--- a/config/main.php
+++ b/config/main.php
@@ -4,7 +4,7 @@ return [
 
     "appName" => "Polyel",
 
-    "encryptionKey" => env('Encryption.KEY'),
+    "encryptionKey" => env('Encryption.KEY', ''),
 
     "encryptionCipher" => "AES-256-CBC",
 

--- a/config/main.php
+++ b/config/main.php
@@ -4,8 +4,18 @@ return [
 
     "appName" => "Polyel",
 
+    /*
+    │------------------------------------------------------------------------------
+    │ Encryption Settings
+    │------------------------------------------------------------------------------
+    │ Here you must set your encryption key if you want to use the Crypt
+    | service built into Polyel that will handle the encryption and decryption
+    | process for you. Polyel uses openssl to perform AES encryption with a MAC.
+    | You must set a securely generated key with the correct length if you want your
+    | encrypted data to be safe.
+    │
+    */
     "encryptionKey" => env('Encryption.KEY', ''),
-
     "encryptionCipher" => "AES-256-CBC",
 
 ];

--- a/config/main.php
+++ b/config/main.php
@@ -13,6 +13,8 @@ return [
     | process for you. Polyel uses openssl to perform AES encryption with a MAC.
     | You must set a securely generated key with the correct length if you want your
     | encrypted data to be safe.
+    |
+    | Current supported ciphers are: AES-128-CBC, AES-256-CBC
     │
     */
     "encryptionKey" => env('Encryption.KEY', ''),


### PR DESCRIPTION
Support for AES-128-CBC and AES-256-CBC with a MAC auth using the `openssl` lib.

Support for AES-128-GCM and AES-256-GCM using the `openssl` lib with IV cryptographically generated using `random_bytes`.